### PR TITLE
Update ruby_installer.rb for ruby 2.3.1

### DIFF
--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -180,7 +180,7 @@ module RubyInstaller
 
     Ruby23 = OpenStruct.new(
       :number  => "23",
-      :version => "2.3.0",
+      :version => "2.3.1",
       :short_version => 'ruby23',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.3/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_3',
@@ -197,7 +197,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.3.0.tar.bz2"
+        "ruby-2.3.1.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk


### PR DESCRIPTION
- fixes #318
- seems to work when I tested locally `¯\_(ツ)_/¯`
